### PR TITLE
Expose className on parent div

### DIFF
--- a/src/BlocklyWorkspace.jsx
+++ b/src/BlocklyWorkspace.jsx
@@ -18,6 +18,7 @@ var BlocklyWorkspace = React.createClass({
   propTypes: {
     initialXml: React.PropTypes.string,
     workspaceConfiguration: React.PropTypes.object,
+    className: React.PropTypes.string,
     wrapperDivClassName: React.PropTypes.string,
     xmlDidChange: React.PropTypes.func,
     toolboxMode: React.PropTypes.oneOf(['CATEGORIES', 'BLOCKS'])
@@ -101,7 +102,7 @@ var BlocklyWorkspace = React.createClass({
     }
 
     return (
-      <div className={this.props.wrapperDivClassName}>
+      <div className={this.props.className}>
         <xml style={{display: "none"}} ref="dummyToolbox">
           {dummyToolboxContent}
         </xml>


### PR DESCRIPTION
Previously `wrapperDivClassName` was referenced in two places; I've split this into className on the root node and wrapperDivClassName on the wrapper div.