### PR TITLE
Fix ReactDOM reference

### DIFF
--- a/src/BlocklyToolboxCategory.jsx
+++ b/src/BlocklyToolboxCategory.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutableRenderMixin from 'react-immutable-render-mixin';
 


### PR DESCRIPTION
`componentDidMount` references `ReactDOM` but it wasn't imported.