### PR TITLE
Add colour support to categories

### DIFF
--- a/src/BlocklyToolbox.jsx
+++ b/src/BlocklyToolbox.jsx
@@ -23,6 +23,7 @@ var BlocklyToolbox = React.createClass({
         return <BlocklyToolboxCategory
           name={category.get('name')}
           custom={category.get('custom')}
+          colour={category.get('colour')}
           key={"category_" + category.get('name') + "_" + i}
           blocks={category.get('blocks')}
           categories={category.get('categories')} />;

--- a/src/BlocklyToolboxCategory.jsx
+++ b/src/BlocklyToolboxCategory.jsx
@@ -10,6 +10,7 @@ var BlocklyToolboxCategory = React.createClass({
   propTypes: {
     name: React.PropTypes.string,
     custom: React.PropTypes.string,
+    colour: React.PropTypes.string,
     categories: ImmutablePropTypes.list,
     blocks: ImmutablePropTypes.list
   },
@@ -24,16 +25,11 @@ var BlocklyToolboxCategory = React.createClass({
         return <BlocklyToolboxCategory
           name={category.get('name')}
           custom={category.get('custom')}
+          colour={category.get('colour')}
           key={key}
           blocks={category.get('blocks')}
           categories={category.get('categories')} />;
       }
-    }
-  },
-
-  componentDidMount: function() {
-    if (this.props.custom) {
-      ReactDOM.findDOMNode(this.refs.category).setAttribute('custom', this.props.custom);
     }
   },
 
@@ -42,7 +38,7 @@ var BlocklyToolboxCategory = React.createClass({
     var blocks = (this.props.blocks || []).map(BlocklyToolboxBlock.renderBlock);
 
     return (
-      <category name={this.props.name} ref="category">
+      <category is name={this.props.name} custom={this.props.custom} colour={this.props.colour} ref="category">
         {blocks}
         {subcategories}
       </category>


### PR DESCRIPTION
This replaces #3 because if we use the `is` ([`isCustomComponent`](https://github.com/facebook/react/blob/a3e576e1bb80f674fa685966ce415fc65238638c/src/renderers/dom/shared/ReactDOMComponent.js#L462-L464)) property then all props are honoured and there's no need for the `setAttribute` workaround.

Although `isCustomComponent` doesn't seem to be documented, it **is** (hah!) tested for:

https://github.com/facebook/react/commit/7256f0976ceb2b37b3a111201ee5151315586b32