### PR TITLE
Fix issue preventing readOnly mode working

### DIFF
--- a/src/BlocklyEditor.jsx
+++ b/src/BlocklyEditor.jsx
@@ -17,7 +17,8 @@ var BlocklyEditor = React.createClass({
   },
 
   toolboxDidUpdate: function() {
-    if (this.refs.workspace) {
+    var workspaceConfiguration = this.props.workspaceConfiguration || {};
+    if (this.refs.workspace && !workspaceConfiguration.readOnly) {
       this.refs.workspace.toolboxDidUpdate(ReactDOM.findDOMNode(this.refs.toolbox));
     }
   },


### PR DESCRIPTION
If you set `readOnly: true` in `workspaceConfiguration` then blockly initialises with a null `languageTree`:

https://github.com/google/blockly/blob/31055ac2eb2731b3790ae085a5788c6edf0085f5/core/options.js#L40

Later when you call `toolboxDidUpdate`, Blockly throws `'Existing toolbox is null.  Can\'t create new toolbox.'`:

https://github.com/google/blockly/blob/31055ac2eb2731b3790ae085a5788c6edf0085f5/core/workspace_svg.js#L1094

This change works around this by skipping `toolboxDidUpdate` if `readOnly` is true.