### PR TITLE
Catch errors thrown by Blockly when importing XML

### DIFF
--- a/src/BlocklyEditor.jsx
+++ b/src/BlocklyEditor.jsx
@@ -13,6 +13,7 @@ var BlocklyEditor = React.createClass({
     toolboxCategories: React.PropTypes.array,
     toolboxBlocks: React.PropTypes.array,
     xmlDidChange: React.PropTypes.func,
+    onImportXmlError: React.PropTypes.func,
     processToolboxCategory: React.PropTypes.func
   },
 
@@ -59,6 +60,7 @@ var BlocklyEditor = React.createClass({
           ref="toolbox" />
         <BlocklyWorkspace ref="workspace"
           initialXml={this.props.initialXml}
+          onImportXmlError={this.props.onImportXmlError}
           toolboxMode={toolboxMode}
           xmlDidChange={this.xmlDidChange}
           wrapperDivClassName={this.props.wrapperDivClassName}

--- a/src/BlocklyEditor.jsx
+++ b/src/BlocklyEditor.jsx
@@ -34,7 +34,7 @@ var BlocklyEditor = React.createClass({
   },
 
   importFromXml: function(xml) {
-    this.refs.workspace.importFromXml(xml);
+    return this.refs.workspace.importFromXml(xml);
   },
 
   resize: function() {

--- a/src/BlocklyWorkspace.jsx
+++ b/src/BlocklyWorkspace.jsx
@@ -40,9 +40,10 @@ var BlocklyWorkspace = React.createClass({
     );
 
     if (this.state.xml) {
-      this.importFromXml(this.state.xml);
-      if (this.props.xmlDidChange) {
-        this.props.xmlDidChange(this.state.xml);
+      if (this.importFromXml(this.state.xml)) {
+        this.xmlDidChange();
+      } else {
+        this.setState({xml: null}, this.xmlDidChange);
       }
     }
 
@@ -52,16 +53,17 @@ var BlocklyWorkspace = React.createClass({
         return;
       }
 
-      this.setState({xml: newXml}, function() {
-        if (this.props.xmlDidChange) {
-          this.props.xmlDidChange(this.state.xml);
-        }
-      }.bind(this));
+      this.setState({xml: newXml}, this.xmlDidChange);
     }.bind(this), 200));
   },
 
   importFromXml: function(xml) {
-    Blockly.Xml.domToWorkspace(this.state.workspace, Blockly.Xml.textToDom(xml));
+    try {
+      Blockly.Xml.domToWorkspace(this.state.workspace, Blockly.Xml.textToDom(xml));
+      return true;
+    } catch (e) {
+      return false;
+    }
   },
 
   componentWillReceiveProps: function(newProps) {
@@ -78,6 +80,12 @@ var BlocklyWorkspace = React.createClass({
 
   shouldComponentUpdate: function() {
     return false;
+  },
+
+  xmlDidChange: function() {
+    if (this.props.xmlDidChange) {
+      this.props.xmlDidChange(this.state.xml);
+    }
   },
 
   toolboxDidUpdate: function(toolboxNode) {

--- a/src/BlocklyWorkspace.jsx
+++ b/src/BlocklyWorkspace.jsx
@@ -20,6 +20,7 @@ var BlocklyWorkspace = React.createClass({
     workspaceConfiguration: React.PropTypes.object,
     wrapperDivClassName: React.PropTypes.string,
     xmlDidChange: React.PropTypes.func,
+    onImportXmlError: React.PropTypes.func,
     toolboxMode: React.PropTypes.oneOf(['CATEGORIES', 'BLOCKS'])
   },
 
@@ -62,6 +63,9 @@ var BlocklyWorkspace = React.createClass({
       Blockly.Xml.domToWorkspace(this.state.workspace, Blockly.Xml.textToDom(xml));
       return true;
     } catch (e) {
+      if (this.props.onImportXmlError) {
+        this.props.onImportXmlError(e);
+      }
       return false;
     }
   },


### PR DESCRIPTION
I'm not sure if this is how you want to handle it (e.g. do you want a better way of reporting it to the calling code?) but for now it at least stops the code crashing in `componentDidMount` on bad XML.