### PR TITLE
Update react-immutable-proptypes package

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "immutable": "^3.7.6",
-    "react-immutable-proptypes": "^1.7.0",
+    "react-immutable-proptypes": "^2.1.0",
     "react-immutable-render-mixin": "^0.9.5"
   },
   "peerDependencies": {


### PR DESCRIPTION
I've been getting this warning:
https://facebook.github.io/react/warnings/dont-call-proptypes.html

Looks like the react-immutable-proptypes already followed the instructions to get rid of the warning:
https://github.com/HurricaneJames/react-immutable-proptypes/commit/f4edf84ca314399e6976e4299c5e25667f6679e1