### PR TITLE
Bugfix for categories with single block

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start": "webpack-dev-server --config webpack.config.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "prepublishOnly": "babel ./src --out-dir ./dist-modules",
-    "prepublish:watch": "babel ./src --watch --out-dir ./dist-modules"
+    "prepublish:watch": "babel ./src --watch --out-dir ./dist-modules",
+    "prepare": "npm run build"
   },
   "author": "Nat Budin <nbudin@patientslikeme.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "prepublishOnly": "babel ./src --out-dir ./dist-modules",
     "prepublish:watch": "babel ./src --watch --out-dir ./dist-modules",
-    "prepare": "npm run build"
+    "prepare": "npm run prepublishOnly"
   },
   "author": "Nat Budin <nbudin@patientslikeme.com>",
   "license": "MIT",

--- a/src/BlocklyHelper.jsx
+++ b/src/BlocklyHelper.jsx
@@ -80,6 +80,9 @@ function transformed(result) {
     cNew.blocks = [];
     const blocks = c.block;
     if (blocks) {
+      if(!(blocks instanceof Array)){
+        cNew.blocks[0] = blocks;
+      }
       for (let j = 0; j < blocks.length; j++) {
         const b = blocks[j];
         const bNew = {};


### PR DESCRIPTION
Before this a single block in a category would not be shown in the toolbox because the XML-DOM would return an object instead of an array.

This patch also includes a new prepare script which calls prepublishOnly to let npm run this when you use a github style dependency - this enables testing of the fork.

Let me know if you want me to squash before merging