### PR TITLE
Addition of expanded property in categories

### DIFF
--- a/src/BlocklyToolbox.jsx
+++ b/src/BlocklyToolbox.jsx
@@ -62,6 +62,7 @@ class BlocklyToolbox extends React.Component {
       name={category.get('name')}
       custom={category.get('custom')}
       colour={category.get('colour')}
+      expanded={category.get('expanded')}
       key={`category_${category.get('name')}_${i}`}
       blocks={category.get('blocks')}
       categories={category.get('categories')}

--- a/src/BlocklyToolboxCategory.jsx
+++ b/src/BlocklyToolboxCategory.jsx
@@ -9,6 +9,7 @@ class BlocklyToolboxCategory extends React.PureComponent {
     name: PropTypes.string,
     custom: PropTypes.string,
     colour: PropTypes.string,
+    expanded: PropTypes.string,
     categories: ImmutablePropTypes.list,
     blocks: ImmutablePropTypes.list,
   };
@@ -17,6 +18,7 @@ class BlocklyToolboxCategory extends React.PureComponent {
     name: null,
     custom: null,
     colour: null,
+    expanded: null,
     categories: null,
     blocks: null,
   };
@@ -31,6 +33,7 @@ class BlocklyToolboxCategory extends React.PureComponent {
       name={category.get('name')}
       custom={category.get('custom')}
       colour={category.get('colour')}
+      expanded={category.get('expanded')}
       key={key}
       blocks={category.get('blocks')}
       categories={category.get('categories')}
@@ -42,7 +45,7 @@ class BlocklyToolboxCategory extends React.PureComponent {
     const blocks = (this.props.blocks || []).map(BlocklyToolboxBlock.renderBlock);
 
     return (
-      <category name={this.props.name} custom={this.props.custom} colour={this.props.colour}>
+      <category name={this.props.name} custom={this.props.custom} colour={this.props.colour} expanded={this.props.expanded}>
         {blocks}
         {subcategories}
       </category>


### PR DESCRIPTION
I'm currently using react-blockly-component in a project and need to use the [`expanded` property on category](https://developers.google.com/blockly/guides/configure/web/toolbox#expanded). This should do it :)